### PR TITLE
Refactor invoice printing and sharing functionality

### DIFF
--- a/lib/appwrite.models.dart
+++ b/lib/appwrite.models.dart
@@ -53,6 +53,7 @@ class AppwriteClient {
   late final Realtime realtime = Realtime(client);
   late final Functions functions = Functions(client);
   late final Avatars avatars = Avatars(client);
+  late final Storage storage = Storage(client);
 
   String? overrideDatabaseId;
 
@@ -2635,7 +2636,7 @@ class OrderCoupons extends AppwriteModel<OrderCoupons> {
     relatedCollection: 'orders',
     relationType: RelationshipType.oneToMany,
     twoWay: true,
-    twoWayKey: 'orderCoupons',
+    twoWayKey: 'coupons',
     onDelete: OnDelete.cascade,
     side: Side.child,
   );
@@ -2802,6 +2803,185 @@ class OrderCoupons extends AppwriteModel<OrderCoupons> {
       collectionInfo.databaseId,
       collectionInfo.$id,
       OrderCoupons.fromAppwrite,
+      this,
+    );
+  }
+
+  Future<Result<void, String>> delete() async {
+    return client.delete(
+      collectionInfo.databaseId,
+      collectionInfo.$id,
+      $id,
+    );
+  }
+}
+
+
+
+class PdfTemplates extends AppwriteModel<PdfTemplates> {
+  static const collectionInfo = CollectionInfo(
+    $id: '66ec10e100342209605d',
+    $permissions: ['create("label:validProductKey")'],
+    databaseId: 'dev',
+    name: 'pdfTemplates',
+    enabled: true,
+    documentSecurity: true,
+  );
+
+  final String template;
+	final String title;
+
+  PdfTemplates._({
+    required this.template,
+		required this.title,
+    required super.$id,
+    required super.$collectionId,
+    required super.$databaseId,
+    required super.$createdAt,
+    required super.$updatedAt,
+    required super.$permissions,
+  })  : assert(template.isNotEmpty),
+				assert(template.length <= 128000),
+				assert(title.isNotEmpty),
+				assert(title.length <= 128);
+
+  factory PdfTemplates({
+    required String template,
+		required String title,
+  }) {
+    return PdfTemplates._(
+      template: template,
+			title: title,
+      $id: ID.unique(),
+      $collectionId: collectionInfo.$id,
+      $databaseId: collectionInfo.databaseId,
+      $createdAt: DateTime.now().toUtc(),
+      $updatedAt: DateTime.now().toUtc(),
+      $permissions: collectionInfo.$permissions,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'template': template,
+			'title': title
+    };
+  }
+
+  @override
+  Map<String, dynamic> toAppwrite({
+    bool isChild = false,
+    bool includeRelations = true,
+  }) {
+    return {
+      'template': template,
+			'title': title,
+      if (isChild) '\$id': $id,
+    };
+  }
+
+  @override
+  PdfTemplates copyWith({
+    String? template,
+		String? title,
+    String? $id,
+    String? $collectionId,
+    String? $databaseId,
+    DateTime? $createdAt,
+    DateTime? $updatedAt,
+    List<String>? $permissions,
+  }) {
+    return PdfTemplates._(
+      template: template ?? this.template,
+			title: title ?? this.title,
+      $id: $id ?? this.$id,
+      $collectionId: $collectionId ?? this.$collectionId,
+      $databaseId: $databaseId ?? this.$databaseId,
+      $createdAt: $createdAt ?? this.$createdAt,
+      $updatedAt: $updatedAt ?? this.$updatedAt,
+      $permissions: $permissions ?? this.$permissions,
+    );
+  }
+
+  @override
+  String toString() {
+    return toJson().toString();
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is PdfTemplates &&
+      template == other.template &&
+			title == other.title &&
+      other.$id == $id;
+  }
+
+  @override
+  int get hashCode {
+    return Object.hashAllUnordered([
+      template,
+			title,
+      $id,
+    ]);
+  }
+
+  factory PdfTemplates.fromAppwrite(Document doc) {
+    return PdfTemplates._(
+      template: doc.data['template'],
+			title: doc.data['title'],
+      $id: doc.$id,
+      $collectionId: doc.$collectionId,
+      $databaseId: doc.$databaseId,
+      $createdAt: DateTime.parse(doc.$createdAt),
+      $updatedAt: DateTime.parse(doc.$updatedAt),
+      $permissions: List<String>.unmodifiable(doc.$permissions),
+    );
+  }
+
+// API
+
+  static AppwriteClient get client => GetIt.I.get<AppwriteClient>();
+  static String get databaseId => GetIt.I.get<AppwriteClient>().overrideDatabaseId ?? collectionInfo.databaseId;
+
+  static Future<Result<(int, List<PdfTemplates>), String>> page({
+    int limit = 25,
+    int? offset,
+    PdfTemplates? last,
+  }) async {
+    return client.page<PdfTemplates>(
+      collectionInfo.databaseId,
+      collectionInfo.$id,
+      PdfTemplates.fromAppwrite,
+      limit: limit,
+      offset: offset,
+      last: last,
+    );
+  }
+
+  static Future<Result<PdfTemplates, String>> get(String id) async {
+    return client.get<PdfTemplates>(
+      collectionInfo.databaseId,
+      collectionInfo.$id,
+      id,
+      PdfTemplates.fromAppwrite,
+    );
+  }
+
+  Future<Result<PdfTemplates, String>> create() async {
+    return client.create<PdfTemplates>(
+      collectionInfo.databaseId,
+      collectionInfo.$id,
+      PdfTemplates.fromAppwrite,
+      this,
+    );
+  }
+
+  Future<Result<PdfTemplates, String>> update() async {
+    return client.update<PdfTemplates>(
+      collectionInfo.databaseId,
+      collectionInfo.$id,
+      PdfTemplates.fromAppwrite,
       this,
     );
   }

--- a/lib/common/show_result_info.dart
+++ b/lib/common/show_result_info.dart
@@ -3,7 +3,7 @@ import 'package:result_type/result_type.dart';
 
 Future<void> showResultInfo<T>(BuildContext context, Result<T, String> result,
     {String? successMessage}) async {
-  if (result.isFailure) {
+  if (result.isFailure && context.mounted) {
     await displayInfoBar(context,
         builder: (context, close) => InfoBar(
               title: const Text('Error'),

--- a/lib/feature/invoices/input.dart
+++ b/lib/feature/invoices/input.dart
@@ -18,7 +18,7 @@ class InvoiceInputDialog extends StatefulWidget {
 
 class _InvoiceInputDialogState extends State<InvoiceInputDialog> {
   final _formKey = GlobalKey<FormState>();
-  late DateTime? _date = widget.invoice?.date ?? DateTime.now();
+  late DateTime _date = widget.invoice?.date.toLocal() ?? DateTime.now();
   late String? _name = widget.invoice?.name;
   late String? _notes = widget.invoice?.notes;
   late int? _amount = widget.invoice?.amount;
@@ -36,14 +36,14 @@ class _InvoiceInputDialogState extends State<InvoiceInputDialog> {
               late final Invoices invoice;
               if (widget.invoice != null) {
                 invoice = widget.invoice!.copyWith(
-                  date: _date,
+                  date: _date.toUtc(),
                   name: _name,
                   notes: _notes,
                   amount: _amount,
                 );
               } else {
                 final invoiceNumber = await newInvoiceNumber(
-                  _date,
+                  _date.toUtc(),
                 );
 
                 if (!context.mounted) return;
@@ -58,7 +58,7 @@ class _InvoiceInputDialogState extends State<InvoiceInputDialog> {
                 }
                 invoice = Invoices(
                   invoiceNumber: invoiceNumber.success,
-                  date: _date!,
+                  date: _date.toUtc(),
                   name: _name!,
                   notes: _notes,
                   amount: _amount!,
@@ -86,7 +86,7 @@ class _InvoiceInputDialogState extends State<InvoiceInputDialog> {
               InfoLabel(
                 label: "Date",
                 child: DatePicker(
-                  selected: _date!,
+                  selected: _date,
                   onChanged: (value) => _date = value,
                 ),
               ),

--- a/lib/feature/invoices/list_page.dart
+++ b/lib/feature/invoices/list_page.dart
@@ -3,11 +3,13 @@ import 'dart:async';
 import 'package:appwrite/appwrite.dart';
 import 'package:auto_route/auto_route.dart';
 import 'package:fluent_ui/fluent_ui.dart';
+import 'package:result_type/result_type.dart';
 import 'package:stibu/appwrite.models.dart';
 import 'package:stibu/common/datetime_formatter.dart';
 import 'package:stibu/common/is_large_screen.dart';
 import 'package:stibu/common/models_extensions.dart';
 import 'package:stibu/common/new_ids.dart';
+import 'package:stibu/common/show_result_info.dart';
 import 'package:stibu/feature/app_state/realtime_subscriptions.dart';
 import 'package:stibu/feature/invoices/info_card.dart';
 import 'package:stibu/feature/invoices/input.dart';
@@ -212,16 +214,36 @@ class _InvoiceListPageState extends State<InvoiceListPage> {
                     }
                   },
                 ),
+              ],
                 CommandBarButton(
                   icon: const Icon(FluentIcons.print),
                   label: const Text('Print'),
                   onPressed: () async {
                     final invoice = _invoices[selectedIndex!];
 
-                    await shareInvoice(_invoices[selectedIndex!]);
+                  if (invoice.canUpdate) {
+                    final appwrite = getIt<AppwriteClient>();
+                    final user = await appwrite.account.get();
+
+                    try {
+                      await appwrite.databases.updateDocument(
+                        databaseId: Invoices.collectionInfo.databaseId,
+                        collectionId: Invoices.collectionInfo.$id,
+                        documentId: invoice.$id,
+                        permissions: [Permission.read(Role.user(user.$id))],
+                      );
+                    } catch (e) {
+                      if (context.mounted) {
+                        await showResultInfo(context, Failure(e.toString()));
+                      }
+                      return;
+                    }
+                  }
+
+                  final result = await shareInvoice(invoice);
+                  if (context.mounted) await showResultInfo(context, result);
                   },
-                )
-              ],
+              )
             ],
           ),
         ),

--- a/lib/feature/invoices/list_page.dart
+++ b/lib/feature/invoices/list_page.dart
@@ -11,6 +11,7 @@ import 'package:stibu/common/new_ids.dart';
 import 'package:stibu/feature/app_state/realtime_subscriptions.dart';
 import 'package:stibu/feature/invoices/info_card.dart';
 import 'package:stibu/feature/invoices/input.dart';
+import 'package:stibu/feature/invoices/pdf/common.dart';
 import 'package:stibu/main.dart';
 
 Future<Invoices?> _showInvoiceCreateDialog(BuildContext context) async {
@@ -211,35 +212,16 @@ class _InvoiceListPageState extends State<InvoiceListPage> {
                     }
                   },
                 ),
-                // CommandBarButton(
-                //   icon: const Icon(FluentIcons.delete),
-                //   label: const Text('Delete'),
-                //   onPressed: () async {
-                //     final result = await _invoices[selectedIndex!].delete();
+                CommandBarButton(
+                  icon: const Icon(FluentIcons.print),
+                  label: const Text('Print'),
+                  onPressed: () async {
+                    final invoice = _invoices[selectedIndex!];
 
-                //     if (!context.mounted) return;
-
-                //     if (result.isFailure) {
-                //       await displayInfoBar(context,
-                //           builder: (context, close) => InfoBar(
-                //                 title: const Text("Error"),
-                //                 content: Text(result.failure),
-                //                 severity: InfoBarSeverity.error,
-                //               ));
-                //     } else {
-                //       await displayInfoBar(context,
-                //           builder: (context, close) => const InfoBar(
-                //                 title: Text("Success"),
-                //                 content: Text("Receipt deleted"),
-                //                 severity: InfoBarSeverity.success,
-                //               ));
-                //       setState(() {
-                //         selectedIndex = null;
-                //       });
-                //     }
-                //   },
-                // ),
-              ]
+                    await shareInvoice(_invoices[selectedIndex!]);
+                  },
+                )
+              ],
             ],
           ),
         ),

--- a/lib/feature/invoices/pdf/basic_template.dart
+++ b/lib/feature/invoices/pdf/basic_template.dart
@@ -188,3 +188,114 @@ Future<Document> generateBasicInvoiceWithOrder(Invoices invoice) async {
 
   return pdf;
 }
+
+
+Future<Document> generateBasicInvoiceWithoutOrder(Invoices invoice) async {
+  assert(invoice.order == null);
+
+  final pdf = Document();
+
+  final font = await PdfGoogleFonts.robotoRegular();
+  final fontBold = await PdfGoogleFonts.robotoBold();
+
+  pdf.addPage(Page(
+    pageFormat: PdfPageFormat.a4,
+    orientation: PageOrientation.portrait,
+    build: (context) {
+      TextStyle defaultTextStyle =
+          TextStyle(fontSize: 10, font: font, fontBold: fontBold);
+
+      return SizedBox(
+          width: PdfPageFormat.a4.availableWidth,
+          height: PdfPageFormat.a4.availableHeight / 2,
+          child: Column(
+            children: [
+              Padding(
+                padding:
+                    const EdgeInsets.symmetric(vertical: 10, horizontal: 20),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text(
+                      'Quittung',
+                      textAlign: TextAlign.left,
+                      style: defaultTextStyle.copyWith(
+                        fontSize: 15,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    Text('Nr: ${invoice.invoiceNumber}',
+                        textAlign: TextAlign.right, style: defaultTextStyle),
+                  ],
+                ),
+              ),
+              Container(
+                width: PdfPageFormat.a5.availableHeight / (3 / 4),
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(
+                    color: PdfColors.black,
+                    width: 1,
+                  ),
+                ),
+                margin: const EdgeInsets.symmetric(vertical: 5, horizontal: 20),
+                padding: const EdgeInsets.all(10),
+                child: Text(
+                  invoice.name,
+                  textAlign: TextAlign.center,
+                  style: defaultTextStyle,
+                  maxLines: 3,
+                ),
+              ),
+              SizedBox(
+                width: PdfPageFormat.a5.availableHeight,
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(20, 0, 20, 5),
+                  child: Text(
+                    'Gesamtbetrag: ${invoice.amount.currency.format()}',
+                    textAlign: TextAlign.right,
+                    style: defaultTextStyle,
+                  ),
+                ),
+              ),
+              SizedBox(
+                width: PdfPageFormat.a5.availableHeight,
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(20, 5, 20, 0),
+                  child: Text(
+                    'Datum: ${invoice.date.formatDate()}',
+                    textAlign: TextAlign.left,
+                    style: defaultTextStyle,
+                  ),
+                ),
+              ),
+              SizedBox(
+                width: PdfPageFormat.a5.availableHeight,
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(20, 5, 20, 10),
+                  child: Text(
+                    'Ort: ',
+                    textAlign: TextAlign.left,
+                    style: defaultTextStyle,
+                  ),
+                ),
+              ),
+              SizedBox(
+                width: PdfPageFormat.a5.availableHeight,
+                child: Padding(
+                  padding:
+                      const EdgeInsets.symmetric(vertical: 0, horizontal: 20),
+                  child: Text(
+                    'Unterschrift: ',
+                    textAlign: TextAlign.left,
+                    style: defaultTextStyle,
+                  ),
+                ),
+              ),
+            ],
+          ));
+    },
+  ));
+
+  return pdf;
+}

--- a/lib/feature/invoices/pdf/basic_template.dart
+++ b/lib/feature/invoices/pdf/basic_template.dart
@@ -1,0 +1,190 @@
+import 'package:pdf/pdf.dart';
+import 'package:pdf/widgets.dart';
+import 'package:printing/printing.dart';
+import 'package:stibu/appwrite.models.dart';
+import 'package:stibu/common/datetime_formatter.dart';
+import 'package:stibu/common/models_extensions.dart';
+
+Future<Document> generateInvoice(Invoices invoice) async {
+  assert(invoice.order != null);
+  assert(invoice.order!.products != null);
+  assert(invoice.order!.coupons != null);
+
+  final pdf = Document();
+
+  final font = await PdfGoogleFonts.robotoRegular();
+  final fontBold = await PdfGoogleFonts.robotoBold();
+
+  pdf.addPage(Page(
+    pageFormat: PdfPageFormat.a4,
+    theme: ThemeData(
+      defaultTextStyle: TextStyle(
+        font: font,
+        fontBold: fontBold,
+        fontSize: 10,
+      ),
+    ),
+    build: (context) => Column(
+      children: [
+        Text('Rechnung', style: Theme.of(context).header0),
+        Spacer(),
+        Row(
+          children: [
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisAlignment: MainAxisAlignment.start,
+              children: [
+                Text(invoice.order!.customerName),
+                Text(invoice.order!.street ?? ''),
+                Text(
+                    '${invoice.order!.zip ?? ''} ${invoice.order!.city ?? ''}'),
+              ],
+            ),
+            Spacer(flex: 8),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('Rechnungsnummer:'),
+                Text('Rechnungsdatum:'),
+                Text('Kundennummer:'),
+                Text('Steuernummer:'),
+              ],
+            ),
+            Spacer(),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                Text(invoice.invoiceNumber),
+                Text(invoice.date.formatDate()),
+                Text(invoice.order!.customerId.toString()),
+                Text('347/2360/4564'),
+              ],
+            ),
+          ],
+        ),
+        Spacer(),
+        Table(
+            border: TableBorder.all(
+              width: 0.5,
+            ),
+            columnWidths: {
+              0: const FlexColumnWidth(1),
+              1: const FlexColumnWidth(3),
+              2: const FlexColumnWidth(0.5),
+              3: const FlexColumnWidth(0.75),
+              4: const FlexColumnWidth(0.75),
+            },
+            children: [
+              TableRow(
+                  decoration: const BoxDecoration(
+                    border: Border(
+                      bottom: BorderSide(
+                        width: 1,
+                      ),
+                    ),
+                  ),
+                  children: [
+                    Text('Artikelnummer', textAlign: TextAlign.center),
+                    Text('Artikelbezeichnung', textAlign: TextAlign.center),
+                    Text('Menge', textAlign: TextAlign.center),
+                    Text(
+                      'Einzelpreis\n€',
+                      maxLines: 2,
+                      textAlign: TextAlign.center,
+                    ),
+                    Text(
+                      'Gesamtpreis\nBrutto €',
+                      maxLines: 2,
+                      textAlign: TextAlign.center,
+                    ),
+                  ]),
+              for (final product in invoice.order!.products!)
+                TableRow(
+                  verticalAlignment: TableCellVerticalAlignment.middle,
+                  children: [
+                    Text(product.id.toString(), textAlign: TextAlign.center),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 3),
+                      child: Text(product.title),
+                    ),
+                    Text(
+                      product.quantity.toString(),
+                      textAlign: TextAlign.center,
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 3),
+                      child: Text(
+                        product.price.currency.format(),
+                        textAlign: TextAlign.right,
+                      ),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 3),
+                      child: Text(
+                        product.total.format(),
+                        textAlign: TextAlign.right,
+                      ),
+                    ),
+                  ],
+                ),
+            ]),
+        for (final coupon in invoice.order!.coupons!)
+          Container(
+              alignment: Alignment.centerRight,
+              child: Container(
+                  decoration: const BoxDecoration(
+                    border: Border(
+                      bottom: BorderSide(
+                        width: 0.5,
+                      ),
+                    ),
+                  ),
+                  child: Text(
+                    '${coupon.name}: ${coupon.amount.currency.format()}',
+                  ))),
+        Container(
+            alignment: Alignment.centerRight,
+            child: Container(
+              padding: const EdgeInsets.symmetric(vertical: 2),
+              decoration: const BoxDecoration(
+                border: Border(
+                  bottom: BorderSide(
+                    width: 0.5,
+                  ),
+                ),
+              ),
+              child: Container(
+                decoration: const BoxDecoration(
+                  border: Border(
+                    bottom: BorderSide(
+                      width: 0.5,
+                    ),
+                  ),
+                ),
+                child: Text(
+                  'Gesamtpreis: ${invoice.order!.total.format()}',
+                ),
+              ),
+            )),
+        Spacer(flex: 15),
+        Text(
+          'Es erfolgt kein Ausweis der Umsatzsteuer aufgrund der Anwendung der Kleinunternehmerregelung gem. §19 UstG.',
+          style: Theme.of(context).paragraphStyle.copyWith(
+                fontSize: 8,
+              ),
+        ),
+        Text(
+          'Soweit nicht anders angegeben entspricht das Lieferdatum dem Rechnungsdatum.',
+          style: Theme.of(context).paragraphStyle.copyWith(
+                fontSize: 8,
+              ),
+        ),
+        Padding(padding: const EdgeInsets.symmetric(vertical: 10)),
+        Text('Vielen Dank für dein Vertrauen'),
+        Spacer(flex: 5),
+      ],
+    ),
+  ));
+
+  return pdf;
+}

--- a/lib/feature/invoices/pdf/basic_template.dart
+++ b/lib/feature/invoices/pdf/basic_template.dart
@@ -5,7 +5,7 @@ import 'package:stibu/appwrite.models.dart';
 import 'package:stibu/common/datetime_formatter.dart';
 import 'package:stibu/common/models_extensions.dart';
 
-Future<Document> generateInvoice(Invoices invoice) async {
+Future<Document> generateBasicInvoiceWithOrder(Invoices invoice) async {
   assert(invoice.order != null);
   assert(invoice.order!.products != null);
   assert(invoice.order!.coupons != null);

--- a/lib/feature/invoices/pdf/common.dart
+++ b/lib/feature/invoices/pdf/common.dart
@@ -1,11 +1,61 @@
+import 'package:pdf/widgets.dart';
 import 'package:printing/printing.dart';
+import 'package:result_type/result_type.dart';
 import 'package:stibu/appwrite.models.dart';
 import 'package:stibu/feature/invoices/pdf/basic_template.dart';
+import 'package:stibu/main.dart';
 
-Future<void> shareInvoice(Invoices invoice) async {
-  final pdf = await generateInvoice(invoice);
-  await Printing.sharePdf(
-    bytes: await pdf.save(),
-    filename: 'Rechnung-${invoice.invoiceNumber}.pdf',
-  );
+const invoicesWithOrderDispatch = <String, Future<Document> Function(Invoices)>{
+  'basic': generateBasicInvoiceWithOrder,
+};
+
+const invoicesWithoutOrderDispatch =
+    <String, Future<Document> Function(Invoices)>{};
+
+Future<Document> getDocument(Invoices invoice) async {
+  if (invoice.order == null) {
+    final templatePreferences =
+        (await getIt<AppwriteClient>().account.getPrefs())
+            .data['invoiceTemplateWithoutOrder'];
+
+    if (templatePreferences == null ||
+        !invoicesWithoutOrderDispatch.containsKey(templatePreferences)) {
+      throw Exception('No template found for $templatePreferences');
+    }
+
+    return invoicesWithoutOrderDispatch[templatePreferences]!(invoice);
+  }
+
+  final templatePreferences = (await getIt<AppwriteClient>().account.getPrefs())
+      .data['invoiceTemplateWithOrder'];
+
+  if (templatePreferences == null ||
+      !invoicesWithOrderDispatch.containsKey(templatePreferences)) {
+    throw Exception('No template found for $templatePreferences');
+  }
+
+  return invoicesWithOrderDispatch[templatePreferences]!(invoice);
+}
+
+Future<Result<void, String>> shareInvoice(Invoices invoice) async {
+  try {
+    final appwrite = getIt<AppwriteClient>();
+    final preferences = (await appwrite.account.getPrefs()).data;
+
+    final doc = await getDocument(invoice);
+    final String filenamePattern = preferences['invoiceWithOrderFilename'] ??
+        'Invoice {invoiceDate} - {invoiceNumber}';
+
+    final filename = filenamePattern
+        .replaceAll('{invoiceNumber}', invoice.invoiceNumber)
+        .replaceAll('{invoiceDate}', invoice.date.toIso8601String());
+
+    await Printing.sharePdf(
+      bytes: await doc.save(),
+      filename: '$filename.pdf',
+    );
+    return Success(null);
+  } catch (e) {
+    return Failure(e.toString());
+  }
 }

--- a/lib/feature/invoices/pdf/common.dart
+++ b/lib/feature/invoices/pdf/common.dart
@@ -1,6 +1,7 @@
 import 'package:pdf/widgets.dart';
 import 'package:printing/printing.dart';
 import 'package:result_type/result_type.dart';
+import 'package:sanitize_filename/sanitize_filename.dart';
 import 'package:stibu/appwrite.models.dart';
 import 'package:stibu/feature/invoices/pdf/basic_template.dart';
 import 'package:stibu/main.dart';
@@ -48,9 +49,10 @@ Future<Result<void, String>> shareInvoice(Invoices invoice) async {
     final String filenamePattern = preferences['invoiceWithOrderFilename'] ??
         'Invoice {invoiceDate} - {invoiceNumber}';
 
-    final filename = filenamePattern
+    final filename = sanitizeFilename(filenamePattern
         .replaceAll('{invoiceNumber}', invoice.invoiceNumber)
-        .replaceAll('{invoiceDate}', invoice.date.toIso8601String());
+        .replaceAll('{invoiceDate}',
+            '${invoice.date.year}-${invoice.date.month}-${invoice.date.day}'));
 
     await Printing.sharePdf(
       bytes: await doc.save(),

--- a/lib/feature/invoices/pdf/common.dart
+++ b/lib/feature/invoices/pdf/common.dart
@@ -10,7 +10,9 @@ const invoicesWithOrderDispatch = <String, Future<Document> Function(Invoices)>{
 };
 
 const invoicesWithoutOrderDispatch =
-    <String, Future<Document> Function(Invoices)>{};
+    <String, Future<Document> Function(Invoices)>{
+  'basic': generateBasicInvoiceWithoutOrder,
+};
 
 Future<Document> getDocument(Invoices invoice) async {
   if (invoice.order == null) {
@@ -20,7 +22,7 @@ Future<Document> getDocument(Invoices invoice) async {
 
     if (templatePreferences == null ||
         !invoicesWithoutOrderDispatch.containsKey(templatePreferences)) {
-      throw Exception('No template found for $templatePreferences');
+      return generateBasicInvoiceWithoutOrder(invoice);
     }
 
     return invoicesWithoutOrderDispatch[templatePreferences]!(invoice);
@@ -31,7 +33,7 @@ Future<Document> getDocument(Invoices invoice) async {
 
   if (templatePreferences == null ||
       !invoicesWithOrderDispatch.containsKey(templatePreferences)) {
-    throw Exception('No template found for $templatePreferences');
+    return generateBasicInvoiceWithOrder(invoice);
   }
 
   return invoicesWithOrderDispatch[templatePreferences]!(invoice);

--- a/lib/feature/invoices/pdf/common.dart
+++ b/lib/feature/invoices/pdf/common.dart
@@ -1,0 +1,11 @@
+import 'package:printing/printing.dart';
+import 'package:stibu/appwrite.models.dart';
+import 'package:stibu/feature/invoices/pdf/basic_template.dart';
+
+Future<void> shareInvoice(Invoices invoice) async {
+  final pdf = await generateInvoice(invoice);
+  await Printing.sharePdf(
+    bytes: await pdf.save(),
+    filename: 'Rechnung-${invoice.invoiceNumber}.pdf',
+  );
+}

--- a/lib/feature/settings/settings_page.dart
+++ b/lib/feature/settings/settings_page.dart
@@ -12,8 +12,10 @@ class SettingsPage extends StatefulWidget {
 class _SettingsPageState extends State<SettingsPage> {
   @override
   Widget build(BuildContext context) {
-    return const Center(
-      child: Text("Settings Body"),
-    );
+    return ScaffoldPage.scrollable(
+        header: const PageHeader(
+          title: Text('Settings'),
+        ),
+        children: const []);
   }
 }

--- a/lib/model_generator/common.dart
+++ b/lib/model_generator/common.dart
@@ -55,6 +55,7 @@ class AppwriteClient {
   late final Realtime realtime = Realtime(client);
   late final Functions functions = Functions(client);
   late final Avatars avatars = Avatars(client);
+  late final Storage storage = Storage(client);
 
   String? overrideDatabaseId;
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -829,6 +829,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.28.0"
+  sanitize_filename:
+    dependency: "direct main"
+    description:
+      name: sanitize_filename
+      sha256: "92fc3859d86ca4d087305a52c6823a2f323fa0935b1d8d17e05e00f80b027b03"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.5"
   scroll_pos:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -53,10 +53,10 @@ packages:
     dependency: "direct main"
     description:
       name: appwrite
-      sha256: c717091605055873e0c8d282059e0c07405c54ece6af1e5ec03ebada1c3ea554
+      sha256: "335faac24642aaf66627c21ce26a5c64bcbc3911e624c61b9dfbe0eec7be1342"
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.4"
+    version: "12.0.1"
   archive:
     dependency: transitive
     description:
@@ -85,10 +85,10 @@ packages:
     dependency: "direct main"
     description:
       name: auto_route
-      sha256: bb673104dbdc22667d01ec668df3d2a358b6e3da481428eeb1151933cfc1a7d6
+      sha256: b83e8ce46da7228cdd019b5a11205454847f0a971bca59a7529b98df9876889b
       url: "https://pub.dev"
     source: hosted
-    version: "9.2.0"
+    version: "9.2.2"
   auto_route_generator:
     dependency: "direct dev"
     description:
@@ -289,6 +289,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.8"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "7caf6a750a0c04effbb52a676dce9a4a592e10ad35c34d6d2d0e4811160d5670"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.4+2"
   crypto:
     dependency: transitive
     description:
@@ -301,10 +309,10 @@ packages:
     dependency: transitive
     description:
       name: csslib
-      sha256: "706b5707578e0c1b4b7550f64078f0a0f19dec3f50a178ffae7006b0a9ca58fb"
+      sha256: "831883fb353c8bdc1d71979e5b342c7d88acfbc643113c14ae51e2442ea0f20f"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "0.17.3"
   dart_style:
     dependency: transitive
     description:
@@ -317,10 +325,10 @@ packages:
     dependency: transitive
     description:
       name: device_info_plus
-      sha256: a7fd703482b391a87d60b6061d04dfdeab07826b96f9abd8f5ed98068acc0074
+      sha256: "77f757b789ff68e4eaf9c56d1752309bd9f7ad557cb105b938a7f8eb89e59110"
       url: "https://pub.dev"
     source: hosted
-    version: "10.1.2"
+    version: "9.1.2"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -353,6 +361,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.0"
+  file_picker:
+    dependency: "direct main"
+    description:
+      name: file_picker
+      sha256: "167bb619cdddaa10ef2907609feb8a79c16dfa479d3afaf960f8e223f754bf12"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.1.2"
   fixnum:
     dependency: transitive
     description:
@@ -387,6 +403,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: "9ee02950848f61c4129af3d6ec84a1cfc0e47931abc746b03e7a3bc3e8ff6eda"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.22"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -521,10 +545,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: c1b2e9b5ea78c45e1a0788d29606ba27dc5f71f019f32ca5140f61ef071838cf
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.1"
+    version: "0.6.7"
   json_annotation:
     dependency: transitive
     description:
@@ -625,18 +649,18 @@ packages:
     dependency: transitive
     description:
       name: package_info_plus
-      sha256: a75164ade98cb7d24cfd0a13c6408927c6b217fa60dee5a7ff5c116a58f28918
+      sha256: "7e76fad405b3e4016cd39d08f455a4eb5199723cf594cd1b8916d47140d93017"
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.2"
+    version: "4.2.0"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
       name: package_info_plus_platform_interface
-      sha256: ac1f4a4847f1ade8e6a87d1f39f5d7c67490738642e2542f559ec38c37489a66
+      sha256: "9bc8ba46813a4cc42c66ab781470711781940780fd8beddd0c3da62506d3a6c6"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "2.0.1"
   path:
     dependency: transitive
     description:
@@ -654,7 +678,7 @@ packages:
     source: hosted
     version: "1.0.1"
   path_provider:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path_provider
       sha256: fec0d61223fba3154d87759e3cc27fe2c8dc498f6386c6d6fc80d1afdd1bf378
@@ -709,6 +733,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.11.1"
+  pdf_widget_wrapper:
+    dependency: transitive
+    description:
+      name: pdf_widget_wrapper
+      sha256: c930860d987213a3d58c7ec3b7ecf8085c3897f773e8dc23da9cae60a5d6d0f5
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   petitparser:
     dependency: transitive
     description:
@@ -741,6 +773,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
+  printing:
+    dependency: "direct main"
+    description:
+      name: printing
+      sha256: de1889f30b34029fc46e5de6a9841498850b23d32942a9ee810ca36b0cb1b234
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.13.2"
   pub_semver:
     dependency: transitive
     description:
@@ -1045,18 +1085,18 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
+      sha256: d43c1d6b787bf0afad444700ae7f4db8827f701bc61c255ac8d328c6f4d52062
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "1.0.0"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: "58c6666b342a38816b2e7e50ed0f1e261959630becd4c879c4f26bfa14aa5a42"
+      sha256: d88238e5eac9a42bb43ca4e721edba3c08c6354d4a53063afaa568516217621b
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.5"
+    version: "2.4.0"
   win32:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -57,6 +57,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "12.0.4"
+  archive:
+    dependency: transitive
+    description:
+      name: archive
+      sha256: cb6a278ef2dbb298455e1a713bda08524a175630ec643a242c399c932a0a1f7d
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.6.1"
   args:
     dependency: transitive
     description:
@@ -89,6 +97,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "9.0.0"
+  barcode:
+    dependency: transitive
+    description:
+      name: barcode
+      sha256: ab180ce22c6555d77d45f0178a523669db67f95856e3378259ef2ffeb43e6003
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.8"
+  bidi:
+    dependency: transitive
+    description:
+      name: bidi
+      sha256: "9a712c7ddf708f7c41b1923aa83648a3ed44cfd75b04f72d598c45e5be287f9d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.12"
   bitsdojo_window:
     dependency: "direct main"
     description:
@@ -469,6 +493,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
+  image:
+    dependency: transitive
+    description:
+      name: image
+      sha256: "2237616a36c0d69aef7549ab439b833fb7f9fb9fc861af2cc9ac3eedddd69ca8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.0"
   intl:
     dependency: "direct main"
     description:
@@ -613,6 +645,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.0"
+  path_parsing:
+    dependency: transitive
+    description:
+      name: path_parsing
+      sha256: e3e67b1629e6f7e8100b367d3db6ba6af4b1f0bb80f64db18ef1fbabd2fa9ccf
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   path_provider:
     dependency: transitive
     description:
@@ -661,6 +701,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  pdf:
+    dependency: "direct main"
+    description:
+      name: pdf
+      sha256: "05df53f8791587402493ac97b9869d3824eccbc77d97855f4545cf72df3cae07"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.11.1"
   petitparser:
     dependency: transitive
     description:
@@ -709,6 +757,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
+  qr:
+    dependency: transitive
+    description:
+      name: qr
+      sha256: "5a1d2586170e172b8a8c8470bbbffd5eb0cd38a66c0d77155ea138d3af3a4445"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
   recase:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   printing: ^5.13.2
   path_provider: ^2.1.4
   file_picker: ^8.1.2
+  sanitize_filename: ^1.0.5
 
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,6 +32,7 @@ dependencies:
   http: ^1.2.2
   table_calendar: ^3.1.2
   build: ^2.4.1
+  pdf: ^3.11.1
 
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,7 +33,9 @@ dependencies:
   table_calendar: ^3.1.2
   build: ^2.4.1
   pdf: ^3.11.1
-
+  printing: ^5.13.2
+  path_provider: ^2.1.4
+  file_picker: ^8.1.2
 
 
 dev_dependencies:

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -8,6 +8,7 @@
 
 #include <app_links/app_links_plugin_c_api.h>
 #include <bitsdojo_window_windows/bitsdojo_window_plugin.h>
+#include <printing/printing_plugin.h>
 #include <system_theme/system_theme_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 #include <window_to_front/window_to_front_plugin.h>
@@ -17,6 +18,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("AppLinksPluginCApi"));
   BitsdojoWindowPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("BitsdojoWindowPlugin"));
+  PrintingPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("PrintingPlugin"));
   SystemThemePluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("SystemThemePlugin"));
   UrlLauncherWindowsRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -5,6 +5,7 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   app_links
   bitsdojo_window_windows
+  printing
   system_theme
   url_launcher_windows
   window_to_front


### PR DESCRIPTION
Extracted the invoice printing and sharing functionality into separate functions in the 'common.dart' file. Created a dispatch mechanism to handle different invoice templates based on user preferences. Added support for generating basic invoice templates with order information. Updated the 'shareInvoice' function to use the dispatch mechanism and handle different invoice templates. Removed unnecessary imports and assertions.

Fixes #25