### PR TITLE
Add dialog for creating invoices on orders

### DIFF
--- a/lib/common/models_extensions.dart
+++ b/lib/common/models_extensions.dart
@@ -37,7 +37,8 @@ extension OrdersExtensions on Orders {
 
   Currency get total => productsTotal - couponsTotal;
 
-  Future<Result<Invoices, String>> createInvoice([DateTime? date]) async {
+  Future<Result<Invoices, String>> createInvoice(
+      {DateTime? date, String? note}) async {
     final appwrite = getIt<AppwriteClient>();
     try {
       final invoiceId = await newInvoiceNumber(date);
@@ -49,18 +50,18 @@ extension OrdersExtensions on Orders {
       ];
 
       final doc = await appwrite.databases.createDocument(
-        databaseId: Invoices.databaseId,
-        collectionId: Invoices.collectionInfo.$id,
-        documentId: ID.unique(),
-        data: {
-          "invoiceNumber": invoiceId.success,
-          'date': date?.toIso8601String() ?? DateTime.now().toIso8601String(),
-          "name": "Invoice ${invoiceId.success}",
-          "amount": total.asInt,
-          "order": $id,
-        },
-        permissions: permissions
-      );
+          databaseId: Invoices.databaseId,
+          collectionId: Invoices.collectionInfo.$id,
+          documentId: ID.unique(),
+          data: {
+            "invoiceNumber": invoiceId.success,
+            'date': date?.toIso8601String() ?? DateTime.now().toIso8601String(),
+            "name": "Invoice ${invoiceId.success}",
+            "amount": total.asInt,
+            "notes": note,
+            "order": $id,
+          },
+          permissions: permissions);
 
       // Set order, orderProducts and orderCoupons permissions to read-only
       await appwrite.databases.updateDocument(

--- a/lib/feature/orders/list_detail.dart
+++ b/lib/feature/orders/list_detail.dart
@@ -66,6 +66,97 @@ class OrderInfoCard extends StatelessWidget {
   }
 }
 
+Future<void> createInvoice(BuildContext context, Orders order) async =>
+    await showDialog(
+      context: context,
+      builder: (context) => CreateOrderInvoiceDialog(
+        order: order,
+      ),
+    );
+
+class CreateOrderInvoiceDialog extends StatefulWidget {
+  final Orders order;
+
+  const CreateOrderInvoiceDialog({
+    super.key,
+    required this.order,
+  });
+
+  @override
+  State<CreateOrderInvoiceDialog> createState() =>
+      _CreateOrderInvoiceDialogState();
+}
+
+class _CreateOrderInvoiceDialogState extends State<CreateOrderInvoiceDialog> {
+  DateTime selected = DateTime.now();
+  final controller = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    return ContentDialog(
+      title: const Center(child: Text('Create invoice')),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Center(
+            child: Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: InfoLabel(
+                label: 'Date',
+                child: DatePicker(
+                  selected: selected,
+                  onChanged: (value) {
+                    setState(() {
+                      selected = value;
+                    });
+                  },
+                ),
+              ),
+            ),
+          ),
+          Center(
+            child: Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 295),
+                child: InfoLabel(
+                  label: 'Note',
+                  child: TextBox(
+                    controller: controller,
+                    placeholder: 'Note',
+                    maxLines: 10,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+      actions: [
+        Button(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        Button(
+          onPressed: () async => widget.order
+              .createInvoice(
+            date: selected,
+            note: controller.text,
+          )
+              .then((result) {
+            if (result.isSuccess) {
+              Navigator.of(context).pop();
+            } else {
+              showResultInfo(context, result);
+            }
+          }),
+          child: const Text('Confirm'),
+        ),
+      ],
+    );
+  }
+}
+
 class OrderProductsList extends StatelessWidget {
   final Orders order;
 
@@ -91,10 +182,7 @@ class OrderProductsList extends StatelessWidget {
             CommandBarButton(
               icon: const Icon(FluentIcons.save),
               label: const Text('Create invoice'),
-              onPressed: () async => await order.createInvoice().then(
-                    (value) => showResultInfo(context, value,
-                        successMessage: 'Invoice created'),
-                  ),
+              onPressed: () async => await createInvoice(context, order),
             ),
           ],
         ),


### PR DESCRIPTION
This pull request adds a dialog for creating invoices on orders. The dialog allows the user to select a date and add a note for the invoice. The dialog also includes a cancel and confirm button. When the confirm button is pressed, the order's `createInvoice` method is called with the selected date and note. If the invoice creation is successful, the dialog is closed. Otherwise, an error message is shown.